### PR TITLE
Return wildcard with best known upper bound rather than throwing an exception

### DIFF
--- a/src/main/java/com/googlecode/gentyref/VarMap.java
+++ b/src/main/java/com/googlecode/gentyref/VarMap.java
@@ -72,7 +72,9 @@ class VarMap {
 		} else if (type instanceof TypeVariable) {
 			TypeVariable<?> tv = (TypeVariable<?>) type;
 			if (!map.containsKey(type)) {
-				throw new UnresolvedTypeVariableException(tv);
+        // return a wildcard type with the best known upper bound.
+				Type[] bounds = tv.getBounds();
+				return new WildcardTypeImpl(map(bounds), new Type[0]);
 			}
 			return map.get(type);
 		} else if (type instanceof ParameterizedType) {


### PR DESCRIPTION
Return wildcard with best known upper bound rather than throwing an exception when the type variable resolution is unknown.

I'm trying to determine the actual types in Repositories generated by  Spring Data Commons 1.3.0.RELEASE. A simplified version of the code looks like this:

``` java
public interface CrudRepository<T, ID extends Serializable> extends Repository<T, ID> {
  ...
  <S extends T> S save(S entity);
  ...
}

public interface MyRepository implements CrudRepository<MyEntity, Long> {
  // no methods
}
```

So when I try to do:

``` java
Method method = CrudRepository.class.getMethod("save", Object.class)
GenericTypeReflector.getExactParameterTypes(method, MyRepository.class);
```

S is not defined and I get the appropriate exception ( UnresolvedTypeVariableException) from:

``` java
class VarMap {
  ...
  Type map(Type type) {
    ...
    } else if (type instanceof TypeVariable) {
      TypeVariable<?> tv = (TypeVariable<?>) type;
      if (!map.containsKey(type)) {
        throw new UnresolvedTypeVariableException(tv);
      }
      return map.get(type);
    }
    ...
  }
  ...
}
```

What if instead of that a wildcard is returned with the proper bounds? Does it make sense? Am I missing some possible cases?

``` java
if (!map.containsKey(type)) {
  Type[] bounds = tv.getBounds();
  return new WildcardTypeImpl(map(bounds), new Type[0]);
}
```

The change is working fine for me, at least for my usage scenarios.

Anyway, great job!
