### PR TITLE
add bnd-maven-plugin to generate OSGi manifest

### DIFF
--- a/bnd.bnd
+++ b/bnd.bnd
@@ -1,0 +1,2 @@
+Bundle-SymbolicName: ${project.groupId}.${project.artifactId}
+Export-Package: com.googlecode.gentyref

--- a/pom.xml
+++ b/pom.xml
@@ -75,6 +75,11 @@
 						</goals>
 					</execution>
 				</executions>
+				<configuration>
+                    <archive>
+                        <manifestFile>${project.build.outputDirectory}/META-INF/MANIFEST.MF</manifestFile>
+                    </archive>
+                </configuration>
 			</plugin>
 			<plugin>
 				<groupId>org.apache.maven.plugins</groupId>
@@ -110,7 +115,17 @@
 					<show>public</show>
 				</configuration>
 			</plugin>
-
+			<plugin>
+                <groupId>biz.aQute.bnd</groupId>
+                <artifactId>bnd-maven-plugin</artifactId>
+                <executions>
+                    <execution>
+                        <goals>
+                            <goal>bnd-process</goal>
+                        </goals>
+                    </execution>
+                </executions>
+            </plugin>
 		</plugins>
 	</build>
 	<profiles>


### PR DESCRIPTION
If you need to use gentyref in an OSGi container the manifest must be 
declared. This PR simply uses the bndtools maven plugin to export the package